### PR TITLE
Better fix for the hint crashes

### DIFF
--- a/hints.js
+++ b/hints.js
@@ -571,15 +571,17 @@ function handleAlternateHintInput() {
 								document.getElementById(hintIndexes[i]).value = str;
 							}
 							else if (Hinted[hintIndexes[i]] != true || !Hinted[hintIndexes[i]]) {
+								simOverride = true;
 								if (textSongSpots.includes("text_"+hintIndexes[i])) {
-									document.getElementById("text_"+hintIndexes[i]).click();
+									document.getElementById("text_"+hintIndexes[i]).dispatchEvent(new Event('mousedown'));
 								}
 								else {
 									if(Check[hintIndexes[i]] == "prescription" || Check[hintIndexes[i]] == "claim_check")
 										document.getElementById("trade_location").dispatchEvent(new Event('mousedown'));
-									//else
-									//	document.getElementById(Check[hintIndexes[i]]+"_location").dispatchEvent(new Event('mousedown'));
+									else
+										document.getElementById(Check[hintIndexes[i]]+"_location").dispatchEvent(new Event('mousedown'));
 								}
+								simOverride = false;
 							}
 						}
 					}

--- a/initialize.js
+++ b/initialize.js
@@ -52,6 +52,7 @@ var untracked = 5;
 var questCounter = 0;
 document.getElementById("bait_probability").onclick = function(){untracked -= 1;}
 var simActive = false;
+var simOverride = false;
 var SpoilerJSON;
 var chuCount = 0;
 var rupeeCount = 0;

--- a/main.js
+++ b/main.js
@@ -43,6 +43,7 @@ function midUpdate() {
 		gs_array_builder(); //just moves gs logic into an array
 		refreshLinSo();
 		spawn_inputs(); //handle child and adult spawn input
+		handleAlternateHintInput(); //implements inputting hints into the note box
 		//trackUnreadHints(); updates which hints are still unread
 		if (document.getElementById("presets").value == "S3") {checkGanons();} //Removes ganon's castle checks if player has obtained light arrows, magic and bow
 		if (i >=1 && Player.logically_accessible > previousInLogicChecks || Logic.gold_skulltulas > previousInLogicSkulls) {
@@ -69,7 +70,6 @@ function midUpdate() {
 }
 
 function slowUpdate() {
-    handleAlternateHintInput(); //implements inputting hints into the note box
 	updateInputs(); //implements custom inputs
 	saveStuff(); //save current settings for next use of tracker
 	refreshVersion(); //will highlight patch notes that haven't been read yet

--- a/misc.js
+++ b/misc.js
@@ -489,7 +489,7 @@ function toggleHint(loc) {
 	
 	if(MarkedWotHItemArrow == null) {
 		if(event.which == 1 || event.which == undefined) { // left click, toggle if this item hinted by a sometimes hint or not
-			if(!simActive) {
+			if(!simActive || simOverride) {
 			
 				var itemText = "";
 				


### PR DESCRIPTION
Previously, if you did a check, then found a sometimes hint for it later, it would not be set as Hinted. Now it does get set as Hinted