### PR TITLE
Bug fix for special characters or numbers in check inputs

### DIFF
--- a/misc.js
+++ b/misc.js
@@ -312,12 +312,20 @@ function capitalizeThirdLetter(string) {
     return string.charAt(0) + string.charAt(1) + string.charAt(2).toUpperCase();
 }	
 
+function isLetter(s){
+	return s.match("^[a-zA-Z\(\)]+$");    
+}
+
 function isUpperCase(str) {
-    return str === str.toUpperCase();
+	if(!isLetter(str))
+		return false;
+	return str === str.toUpperCase();
 }
 
 function isLowerCase(str) {
-    return str === str.toLowerCase();
+	if(!isLetter(str))
+		return false;
+	return str === str.toLowerCase();
 }
 
 function timerControl() {


### PR DESCRIPTION
Currently, there's a bug if a check input text box has a character other than a letter (generally due to a typo), then check inputs no longer work properly. This fixes that bug.