### PR TITLE
More dungeon ER functionality

### DIFF
--- a/initialize.js
+++ b/initialize.js
@@ -84,6 +84,7 @@ var dungs_list2 = {"deku":"Deku", "dodongos":"DC", "jabu":"Jabu", "forest_temple
 var dungs_list = ["deku", "dodongos", "jabu", "forest_temple", "fire_temple", "water_temple", "shadow_temple", "spirit_temple", "botw", "ice", "gtg"];
 var dungs_list_short = ["de", "do", "ja", "fo", "fi", "wa", "sh", "sp", "bo", "ic", "gt"];
 var dungs_colors = Array(dungs_list.length).fill("white");
+var dungs_strike = Array(dungs_list.length).fill("none");
 for(let d = 0; d < dungs_list.length; d++) {
 	dungeonToEntrance_ER_dict[dungs_list[d]] = dungs_list[d];
 	entranceToDungeon_ER_dict[dungs_list[d]] = dungs_list[d];

--- a/misc.js
+++ b/misc.js
@@ -203,9 +203,19 @@ function highlightDungeonEntrance(element) {
 	idx = parseInt(element.dataset.idx, 10);
 	if (Number.isNaN(idx) || idx < 0 || idx >= dungs_colors.length) return;
 
-	new_color = dungs_colors[idx] == "white" ? "yellow" : "white";
-	dungs_colors[idx] = new_color;
-	element.style.color = new_color;
+	if (event.button == 0) {  // left click
+		// If strike-though, don't bother changing color.
+		if (dungs_strike[idx] == "line-through") return;
+
+		new_color = dungs_colors[idx] == "white" ? "yellow" : "white";
+		dungs_colors[idx] = new_color;
+		element.style.color = new_color;
+	} if (event.button == 2) {  // right click
+		strike = dungs_strike[idx] == "none" ? "line-through" : "none";
+		dungs_strike[idx] = strike;
+		element.style.textDecoration = strike;
+		element.style.color = strike == "none" ? dungs_colors[idx] : "gray";
+	}
 }
 
 function shuffle(array) {

--- a/stylesheet.css
+++ b/stylesheet.css
@@ -261,6 +261,11 @@ color: red;
 	margin-top: 2px;
 	margin-right:4px;
 }
+.medallions.small {
+	height:14px;
+	width:14px;
+	margin-bottom: 0px;
+}
 #stonePic {
 	height:25px;
 	width:25px;

--- a/ui.js
+++ b/ui.js
@@ -1824,21 +1824,51 @@ function updateDungeonER() {
 			for(i = 0; i < 11; i++) {
 				dungeon_er_inputs.push(er_input_string.substring(i*2,i*2+2));
 			}
-			//console.log(dungeon_er_inputs);
-			
 			
 			for(let d = 0; d < dungs_list.length; d++) {
 				entranceToDungeon_ER_dict[dungs_list[d]] = dungs_list[dungs_list_short.indexOf(dungeon_er_inputs[d])];
 				dungeonToEntrance_ER_dict[dungs_list[dungs_list_short.indexOf(dungeon_er_inputs[d])]] = dungs_list[d];
+
+				med_str = getDungeonERMedStr(entranceToDungeon_ER_dict[dungs_list[d]])
+				color = getDungeonERColor(d);
 				
 				document.getElementById("dungeons_summary").innerHTML +=
-					"<span data-idx='"+d+"' style='color:" + dungs_colors[d] + "' onmousedown='highlightDungeonEntrance(this)'>" +
+					med_str + "<span data-idx='"+d+"' style='color:" + color + "; text-decoration:" + dungs_strike[d] + ";' onmousedown='highlightDungeonEntrance(this)'>" +
 					dungs_list2[dungs_list[d]]+" &#8594; "+dungs_list2[entranceToDungeon_ER_dict[dungs_list[d]]]+"</span><br>";
 			}
 		}
 	}
 	
 	update_dungeon_ER_Logic();
+}
+
+function getDungeonERMedStr(dest) {
+	if (document.getElementById("presets").value == "S9") {
+		dest_code = dest.substring(0,2);
+		med_str = document.getElementById("markMedallions").value;
+		if (dest_code == med_str.substring(0,2)) {  // light med
+			return "<img src='./normal/items/light.png' class='medallions small'>";
+		} else if (dest_code == med_str.substring(2,4)) {  // forest med
+			return "<img src='./normal/items/forest.png' class='medallions small'>";
+		} else if (dest_code == med_str.substring(4,6)) {  // fire med
+			return "<img src='./normal/items/fire.png' class='medallions small'>";
+		} else if (dest_code == med_str.substring(6,8)) {  // water med
+			return "<img src='./normal/items/water.png' class='medallions small'>";
+		} else if (dest_code == med_str.substring(8,10)) {  // shadow med
+			return "<img src='./normal/items/shadow.png' class='medallions small'>";
+		} else if (dest_code == med_str.substring(10,12)) {  // spirit med
+			return "<img src='./normal/items/spirit.png' class='medallions small'>";
+		}
+	}
+	return "";
+}
+
+function getDungeonERColor(i) {
+	if (dungs_strike[i] == "line-through") {
+		return "gray";
+	}
+
+	return dungs_colors[i];
 }
 
 function update_dungeon_ER_Logic() {


### PR DESCRIPTION
Add strikethrough on right click for dungeon entrances, which also grays out the text.

For S9 preset, this will also read the medallion layout and prepend the entrances with the corresponding medallion so that it's easier to spot which entrance->dungeon contains important dungeon rewards.

<img width="713" height="514" alt="image" src="https://github.com/user-attachments/assets/759e2bb4-4938-40fd-a96c-e247b0cf53d1" />
