### PR TITLE
Fix item inputs for songs

### DIFF
--- a/initialize.js
+++ b/initialize.js
@@ -580,8 +580,9 @@ var AreaIndexes = [0,18,31,44,55,72,95,101,103,104,112,119,130,147,154,173,190,2
 var SongIndexes = [1000,467,477,1000,1000,1000,466,1000,475,1000,474,1000,1000,468,1000,1000,10000,471,469,470,1000,1000,473,1000,1000,1000,1000,1000,1000,1000,1000,1000,1000,1000,1000];
 var SongIndexes2 = [1000,467,477,1000,1000,1000,466,1000,475,1000,474,1000,1000,472,1000,1000,1000,471,476,470,1000,1000,473,1000,1000,1000,1000,1000,1000,1000,1000,1000,1000,1000,1000];
 	
-var lastItem = 465;
-var lastSong = 477;
+const lastItem = Locations.indexOf('zeldasSpot') - 1;
+const lastSong = Locations.indexOf('oot');
+const lastOverworldItem = Locations.indexOf('forest_first') - 1;  // Includes Deku, DC, Jabu, Ice
 	
 Location.med1 = "unknown";
 Location.med2 = "unknown";
@@ -1337,7 +1338,7 @@ for (var i = 0; i<Locations.length; i++) {
 		var elem = document.createElement("br"); parent.appendChild(elem);
 	}
 	if (i < AreaIndexes[35]) {
-		var elem = document.createElement("input"); elem.id = Locations[i]; elem.onmousedown = mouse_input; if (i < AreaIndexes[35]) {elem.style.backgroundImage = background; elem.className = "picture_input"; } else {elem.className = "check_input";} parent.appendChild(elem);
+		var elem = document.createElement("input"); elem.id = Locations[i]; elem.className = "picture_input"; elem.onmousedown = mouse_input; elem.style.backgroundImage = background; parent.appendChild(elem);
 		var elem = document.createElement("small"); elem.id = "text_" + Locations[i]; elem.className = "check_text"; elem.onmousedown = junk; elem.innerHTML = Names[i]; /*if (elem.id.includes("text_gs_")) {elem.style.textDecoration = "underline overline";} if (elem.id.includes("text_scrub")) {elem.style.textDecoration = "underline overline";}*/ parent.appendChild(elem);
 		var elem = document.createElement("br"); elem.id = "br_" + Locations[i]; parent.appendChild(elem);
 	}

--- a/ui.js
+++ b/ui.js
@@ -75,6 +75,7 @@ function processInputs() {
 			else if(!Known.bombchus4) {Known.bombchus4 = true;}
 			else if(!Known.bombchus5) {Known.bombchus5 = true;}
 			
+			// TODO: This should be updated to properly handle chus at song locations.
 			document.getElementById("text_" + Locations[i]).dispatchEvent(new Event('mousedown'));
 			document.getElementById(key).value = "";
 		}
@@ -99,14 +100,47 @@ function processInputs() {
 				if(Items2[j] == "wallet" && Known["wallet3"]) continue;
 				if((Items2[j] == "prescription" || Items2[j] == "claim_check") && (Known["prescription"] || Known["claim_check"])) continue;
 				
-				if (j == 0) {
+				if (j == 0) {  // Junk
                     if (isUpperCase(document.getElementById(key).value.charAt(0))) {baitsChecked+=1;}
-                    if (i > lastItem) {songItemChecked = true;}
-                    document.getElementById("text_" + Locations[i]).dispatchEvent(new Event('mousedown')); continue;
+                    if (i > lastItem) {
+						songItemChecked = true;
+						var change = "text_" + document.getElementById(key).id; 
+						document.getElementById(change).innerHTML += ": " + ItemNames2[j]; 
+						junkSong(document.getElementById(key));
+						trackAnimalQuest();
+						break;
+					} else {
+                    	document.getElementById("text_" + Locations[i]).dispatchEvent(new Event('mousedown'));
+					}
+					continue;
                 }
-				if (j == 1) {Check[document.getElementById(key).id]="small_key"; forcedDisplay[i] = true; document.getElementById(key).style.backgroundImage= ""; document.getElementById(key).value = document.getElementById(key).value.toUpperCase(); continue;}
-				if (j == 2) {Check[document.getElementById(key).id]="boss_key"; forcedDisplay[i] = true; document.getElementById(key).style.backgroundImage= ""; document.getElementById(key).value = document.getElementById(key).value.toUpperCase(); continue;}
-				if (j == 4) {Check[document.getElementById(key).id]="bombchus"; forcedDisplay[i] = true; document.getElementById(key).style.backgroundImage= ""; document.getElementById(key).value = document.getElementById(key).value.toUpperCase(); continue;}
+				if (j == 1) {  // Small key
+					// Small key for overworld or song location is currently unsupported.
+					if (i <= lastOverworldItem || i > lastItem) continue;
+
+					Check[document.getElementById(key).id]="small_key";
+					forcedDisplay[i] = true;
+					document.getElementById(key).style.backgroundImage= "";
+					document.getElementById(key).value = document.getElementById(key).value.toUpperCase();
+					continue;
+				}
+				if (j == 2) {  // Boss key
+					// Boss key for overworld or song location is currently unsupported.
+					if (i <= lastOverworldItem || i > lastItem) continue;
+
+					Check[document.getElementById(key).id]="boss_key";
+					forcedDisplay[i] = true;
+					document.getElementById(key).style.backgroundImage= "";
+					document.getElementById(key).value = document.getElementById(key).value.toUpperCase();
+					continue;
+				}
+				if (j == 4) {  // Bombchus
+					Check[document.getElementById(key).id]="bombchus";
+					forcedDisplay[i] = true;
+					document.getElementById(key).style.backgroundImage= "";
+					document.getElementById(key).value = document.getElementById(key).value.toUpperCase();
+					continue;
+				}
 				for (var k = 0; k <= 3; k++) {
 					if (k == 0) {var duplicate = "";}
 					else {var duplicate = k + "";}
@@ -134,7 +168,7 @@ function processInputs() {
                             trackAnimalQuest();
 							break;
 						}
-						else if (i > lastItem && j < 41) {
+						else if (i > lastItem && j < 44) {
 							songItemChecked = true;
 							Check[document.getElementById(key).id] = Items2[j] + duplicate; 
 							Location[Items2[j] + duplicate] = document.getElementById(key).id;
@@ -1261,7 +1295,12 @@ function updateLogicInfo() {
 		if (document.getElementById(str).style.display != "none") {if (document.getElementById(str).style.color == "orange" || document.getElementById(str).style.color == "magenta") {colorChange = true;} else {colorChange = false;}} else {colorChange = false;}
 		if(document.getElementById(str).style.display == "none") {continue;}
 		document.getElementById(str).innerHTML = backUp[i];
-		if (i > lastItem && Check[key] != "unknown") {document.getElementById(str).innerHTML += ": " + capitalizeFirstLetter(ItemNames[Items.indexOf(Check[key])])}
+		if (i > lastItem && Check[key] != "unknown") {
+			// Handle chus separately since they're not in the Items list.
+			itemName = Check[key] == "bombchus" ? "Bombchus" : capitalizeFirstLetter(ItemNames[Items.indexOf(Check[key])]);
+			document.getElementById(str).innerHTML += ": " + itemName;
+			junkSong(document.getElementById(key));
+		}
 		
 		if(i > lastItem && Check[key] != "unknown" && !Player[Check[key]] && (Location_Logic[key] || Location_Peek[key] || Location_Could_Access[key]))
 			document.getElementById(str).style.backgroundColor = "gray";


### PR DESCRIPTION
Disable sk/bk inputs for non-key dungeon checks. This used to break the input box.

TODO: Make junk and chus (and hinted chus) work properly when input for songs locations.