### PR TITLE
Adjust song spacing

### DIFF
--- a/index.html
+++ b/index.html
@@ -14,7 +14,7 @@
 			<div class="dungColumn" id="dung2"></div>
 			<div class="dungColumn" id="dung3"></div>
 			<div class="dungColumn" id="dung4"></div>
-			<div id="songColumn"><div style="width: 120px; height: 25px"><small id = "song_title" class="area_titles">Songs</small></div><span id = "songs"></span>
+			<div id="songColumn"><div style="width: 120px; height: 25px"><small id = "song_title" class="area_titles">Songs</small></div><span id = "songs" class="song_spacing"></span>
                 <img id = "redRupee" class = "rupeeButtons" src = "normal/redRupee.png" onmouseDown="modifyRupees(20)"></img><img id = "blueRupee" class = "rupeeButtons" src = "normal/blueRupee.png" onmouseDown="modifyRupees(5)"></img><small id = "rupeeCount">0</small>
 				<br id="rupeeBreak" class="half_break" style="display: none;"/><img src="./images/farores505050.png" id="faroresimg" class="bonuspics" onmousedown = "highlight(this)"><img src="./images/firearrows505050.png" id="firearrowsimg" class="bonuspics" onmousedown = "highlight(this)"><img src="./images/lens505050.png" id="lensimg" class="bonuspics" onmousedown = "highlight(this)"><img src="./images/chux.png" id="chuButton" onmousedown="enableChus()" class="bonuspics"></img><br />
 				<img src="./images/silverscale505050.png" id="silverscaleimg" class="bonuspics" onmousedown = "highlight(this)"><img src="./images/bottle505050.png" id="bottleimg" class="bonuspics" onmousedown = "highlight(this)"><img src="./images/slingshot505050.png" id="slingshotimg" class="bonuspics" onmousedown = "highlight(this)"><img src="./images/strength3505050.png" id="goldengauntletsimg" class="bonuspics" onmousedown = "highlight(this)">

--- a/stylesheet.css
+++ b/stylesheet.css
@@ -630,6 +630,9 @@ color: red;
 	float: left;
 	width: 130px;
 }
+.song_spacing {
+	line-height: 131%;
+}
 .dungcolumn {
 	margin-top:10px;
   float: left;


### PR DESCRIPTION
Add song spacing so that when songs are added, it retains the same spacing and doesn't cause all the elements underneath to shift upwards. This helps anyone who, for example, puts the hint box in their OBS layout.

Spacing of 131% was picked so that the existing position of elements doesn't change.